### PR TITLE
Fixes an issue with associations not passing options to ArraySerializer.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in active_model_serializers.gemspec
 gemspec
 
-gem "minitest"
+gem "minitest", "~> 5.1"
 
 version = ENV["RAILS_VERSION"] || "4.1"
 

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -139,7 +139,7 @@ module ActiveModel
       self.class._associations.dup.each do |name, options|
         association = object.send(name)
         serializer_class = ActiveModel::Serializer.serializer_for(association)
-        serializer = serializer_class.new(association) if serializer_class
+        serializer = serializer_class.new(association, options[:options]) if serializer_class
 
         if block_given?
           block.call(name, serializer, options[:options])


### PR DESCRIPTION
- this simply allows ArraySerializer to determine what serializer to use if the option is passed.
