### PR TITLE
Allow nested serializers to receive options from a parent

### DIFF
--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -14,7 +14,7 @@ module ActiveModel
 
           if serializer.respond_to?(:each)
             @hash[@root] = serializer.map do |s|
-              self.class.new(s, @options.merge(top: @top)).serializable_hash[@root]
+              self.class.new(s, @options.merge(top: @top)).serializable_hash(options)[@root]
             end
           else
             @hash[@root] = attributes_for_serializer(serializer, @options)


### PR DESCRIPTION
When a `JsonApi` adapter is asked to serialize an `ArraySerializer`, the options that are supplied to `serializable_hash` were previously not applied to the invocation of `serializable_hash` of each of the array serializer's objects' adapters. This makes it so that those options cascade all the way down the tree.

@jejacks0n - can you think of any specific reasons this shouldn't happen? I'm working on applying some attribute caching / multi-fetching to this fork, and this change allows me to build in some recursive cache proxying.