### PR TITLE
Merge attributes for models that are the same by id

### DIFF
--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activemodel", ">= 4.0"
+  spec.add_dependency "activesupport", ">= 4.0"
 
   spec.add_development_dependency "rails", ">= 4.0"
   spec.add_development_dependency "bundler", "~> 1.6"


### PR DESCRIPTION
#### What does this PR do?

Patches the JsonApi adapter to be a little smarter about how / when to include linked associations.

#### Any background context you want to provide?

With many available representations of a given model through different associations, the dumb approach of `push attributes unless attributes are already present` caused duplicate occurrences of a given model. For example, if a comment includes a `parent_post` and a different post includes the same post as a `reposted_source`, and each of those serializer associations includes different things for different reasons, duplicates would occur.

This approach assumes a deep merge of attributes is appropriate. This could be problematic if, for whatever reason, we had an attribute that returned a different value under different circumstances for a given model, but that seems bad in other ways.